### PR TITLE
Multiple forward passes in val and train, with necessary loss changes

### DIFF
--- a/overlaid_plots.py
+++ b/overlaid_plots.py
@@ -12,7 +12,7 @@ from tensorflow.data import TFRecordDataset
 TF_TAGS = ['train/loss', 'val/loss', 'test/loss',
            'train/accuracy', 'val/accuracy', 'test/accuracy']
 COLORS = [
-    'green', 'blue', 'purple', 'orange' 'red', 'black'
+    'green', 'blue', 'purple', 'orange', 'red', 'black'
 ]
 
 def _parse(f):

--- a/overlaid_plots.py
+++ b/overlaid_plots.py
@@ -2,6 +2,8 @@ from argparse import ArgumentParser
 from os import listdir
 from os.path import basename, normpath, join
 
+import matplotlib
+matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import matplotlib.ticker as ticker
 from tensorflow.core.util import event_pb2

--- a/overlaid_plots.py
+++ b/overlaid_plots.py
@@ -1,4 +1,5 @@
 from argparse import ArgumentParser
+import math
 from os import listdir
 from os.path import basename, normpath, join
 
@@ -15,13 +16,13 @@ COLORS = [
     'green', 'blue', 'purple', 'orange', 'red', 'black'
 ]
 
-def _parse(f):
+def _parse(f, limit):
     def get_tag(event):
         return event.summary.ListFields()[0][1][0].tag
 
 
     def get_matching_tag(tag):
-        return lambda d: d.step > 0 and tag == get_tag(d)
+        return lambda d: d.step > 0 and d.step < limit and tag == get_tag(d)
 
 
     def get_val(event):
@@ -73,11 +74,11 @@ def _graph(events, outfile=None):
         plt.show()
 
 
-def main(logdirs, outfile=None):
+def main(logdirs, limit, outfile=None):
     # first get the single file in each directory
     files = {basename(normpath(ld)): join(ld, listdir(ld)[0]) for ld in logdirs}
     # then, get parsed events for each file
-    events = {exp_name: _parse(f) for exp_name, f in files.items()}
+    events = {exp_name: _parse(f, limit) for exp_name, f in files.items()}
     _graph(events, outfile)
 
 
@@ -85,8 +86,9 @@ if __name__ == '__main__':
     parser = ArgumentParser('Plot train/val/loss loss and accuracy curves')
     parser.add_argument('logdirs', nargs='+', help='paths to tensorboard logdirs')
     parser.add_argument('--outfile', '-o', default=None)
+    parser.add_argument('--limit', '-l', type=float, default=math.inf)
     a = parser.parse_args()
     if len(a.logdirs) > len(COLORS):
         print(f'can\'t accept more than {len(COLORS)} inputs')
     else:
-        main(a.logdirs, a.outfile)
+        main(a.logdirs, a.limit, a.outfile)

--- a/parser.py
+++ b/parser.py
@@ -53,6 +53,8 @@ class Parser():
         self.p.add_argument('--val-gumbel', action='store_true',
                 default=False)
 
+        self.p.add_argument('--st', default=False, action='store_true')
+
         self.p.add_argument('--orthogonal', action='store_true', default=False)
         self.p.add_argument('--optimizer', '-o', type=str, default='adam')
         self.p.add_argument('--adjust-lr', action='store_true')

--- a/parser.py
+++ b/parser.py
@@ -48,6 +48,10 @@ class Parser():
 
         self.p.add_argument('--inference-passes', '-i', type=int, default=10,
                 help='number of forward passes during test')
+        self.p.add_argument('--training-passes', type=int, default=1)
+        self.p.add_argument('--val-passes', '-v', type=int, default=1)
+        self.p.add_argument('--val-gumbel', action='store_true',
+                default=False)
 
         self.p.add_argument('--orthogonal', action='store_true', default=False)
         self.p.add_argument('--optimizer', '-o', type=str, default='adam')

--- a/run_model.py
+++ b/run_model.py
@@ -109,7 +109,7 @@ def train(args, model, device, train_loader, optimizer, epoch, criterion,
             if out == None:
                 out = F.softmax(model(inputs), dim=-1)
             else:
-                out += F.softmax(model(inputs), dim=-1)
+                out = torch.add(out, F.softmax(model(inputs), dim=-1))
         out = torch.clamp(out / args.training_passes, min=1e-5)
         pred = out.argmax(dim=1)
 

--- a/run_model.py
+++ b/run_model.py
@@ -8,6 +8,7 @@ from sklearn.metrics import confusion_matrix
 
 import torch
 import torch.nn as nn
+import torch.nn.functional as F
 from torch.utils.tensorboard import SummaryWriter
 
 from optim import ExponentialScheduler, ConstScheduler, LinearScheduler
@@ -103,13 +104,19 @@ def train(args, model, device, train_loader, optimizer, epoch, criterion,
     for batch_idx, (inputs, labels) in enumerate(train_loader):
         inputs, labels = inputs.float().to(device), labels.long().to(device)
         optimizer.zero_grad()
-        out = model(inputs)
+        out = None
+        for _ in range(args.training_passes):
+            if out == None:
+                out = F.softmax(model(inputs), dim=-1)
+            else:
+                out += F.softmax(model(inputs), dim=-1)
+        out = out / args.training_passes
         pred = out.argmax(dim=1)
-        loss = criterion(out, labels)
 
+        loss = criterion(torch.log(out), labels)
         loss.backward()
-
         losses.append(loss.item())
+
         temps.append(avg(model_temps(model)))
         grads.append(avg(model_grads(model)))
         correct += pred.eq(labels.view_as(pred)).sum().item()
@@ -136,15 +143,25 @@ def train(args, model, device, train_loader, optimizer, epoch, criterion,
 
 def val(args, model, device, val_loader, epoch, criterion,
         metrics_writer=None):
-    model.eval()
+    if args.val_gumbel:
+        model.train()
+    else:
+        model.eval()
     losses = []
     correct = 0
     with torch.no_grad():
         for inputs, labels in val_loader:
             inputs, labels = inputs.float().to(device), labels.long().to(device)
-            out = model(inputs)
+            out = None
+            for _ in range(args.val_passes):
+                if out == None:
+                    out = F.softmax(model(inputs), dim=-1)
+                else:
+                    out += F.softmax(model(inputs), dim=-1)
+            out = out / args.val_passes
+
             pred = out.argmax(dim=1)
-            losses.append(criterion(out, labels).sum().item())
+            losses.append(criterion(torch.log(out), labels).sum().item())
             correct += pred.eq(labels.view_as(pred)).sum().item()
 
     if metrics_writer:
@@ -162,12 +179,15 @@ def test(args, model, device, test_loader, epoch, criterion, num_labels,
     with torch.no_grad():
         for inputs, labels in test_loader:
             inputs, labels = inputs.float().to(device), labels.long().to(device)
-            outputs = []
+            out = None
             for _ in range(args.inference_passes):
-                outputs.append(model(inputs))
-            mean_output = torch.mean(torch.stack(outputs), dim=0)
-            pred = mean_output.argmax(dim=1)
-            losses.append(criterion(mean_output, labels).sum().item())
+                if out == None:
+                    out = F.softmax(model(inputs), dim=-1)
+                else:
+                    out += F.softmax(model(inputs), dim=-1)
+            out = out / args.inference_passes
+            pred = out.argmax(dim=1)
+            losses.append(criterion(torch.log(out), labels).sum().item())
             correct += pred.eq(labels.view_as(pred)).sum().item()
             conf_mat += confusion_matrix(labels.cpu().numpy(), pred.cpu().numpy(), labels=range(num_labels))
 
@@ -203,7 +223,7 @@ def setup_logging(args):
 
 def run_model(model, optimizer, start_epoch, args, device, train_loader, 
                  val_loader, test_loader, num_labels):
-    criterion = nn.CrossEntropyLoss()
+    criterion = nn.NLLLoss()
     setup_logging(args)
     metrics_writer = None
     if not args.no_log:

--- a/run_model.py
+++ b/run_model.py
@@ -110,7 +110,7 @@ def train(args, model, device, train_loader, optimizer, epoch, criterion,
                 out = F.softmax(model(inputs), dim=-1)
             else:
                 out += F.softmax(model(inputs), dim=-1)
-        out = out / args.training_passes
+        out = torch.clamp(out / args.training_passes, min=1e-5)
         pred = out.argmax(dim=1)
 
         loss = criterion(torch.log(out), labels)
@@ -158,7 +158,7 @@ def val(args, model, device, val_loader, epoch, criterion,
                     out = F.softmax(model(inputs), dim=-1)
                 else:
                     out += F.softmax(model(inputs), dim=-1)
-            out = out / args.val_passes
+            out = torch.clamp((out / args.val_passes), min=1e-5)
 
             pred = out.argmax(dim=1)
             losses.append(criterion(torch.log(out), labels).sum().item())
@@ -185,7 +185,7 @@ def test(args, model, device, test_loader, epoch, criterion, num_labels,
                     out = F.softmax(model(inputs), dim=-1)
                 else:
                     out += F.softmax(model(inputs), dim=-1)
-            out = out / args.inference_passes
+            out = torch.clamp(out / args.inference_passes, min=1e-5)
             pred = out.argmax(dim=1)
             losses.append(criterion(torch.log(out), labels).sum().item())
             correct += pred.eq(labels.view_as(pred)).sum().item()

--- a/run_model.py
+++ b/run_model.py
@@ -223,6 +223,10 @@ def setup_logging(args):
 
 def run_model(model, optimizer, start_epoch, args, device, train_loader, 
                  val_loader, test_loader, num_labels):
+    if args.st:
+        L.Forward_Onehot = True
+    else:
+        L.Forward_Onehot = False
     criterion = nn.NLLLoss()
     setup_logging(args)
     metrics_writer = None


### PR DESCRIPTION
2 Changes:
1. Loss function changed to NLLLoss, multiple forward pass averaging done on softmaxed values (in constant space), log taken manually before passing to loss function. Had to clip the log lower bound as well
2. Use (1) to implement mfp for train, val, and test in a unified way